### PR TITLE
Add basic card abilities

### DIFF
--- a/style.css
+++ b/style.css
@@ -40,6 +40,14 @@ body {
   font-size: 12px;
 }
 
+.card .abilities {
+  position: absolute;
+  top: 4px;
+  left: 4px;
+  font-size: 10px;
+  text-align: left;
+}
+
 .fade-out {
   animation: fadeOut 0.3s forwards;
 }


### PR DESCRIPTION
## Summary
- add card ability fields (battlecry, end-of-turn, reborn)
- provide a few sample cards using abilities
- display ability labels on card render
- trigger battlecries on play
- trigger end of turn effects before combat
- support reborn mechanic in combat
- reset reborn state between turns
- style for ability labels

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684e547cf74883228701bee106c826a4